### PR TITLE
fix:用正则匹配输入的薪资，无需以数字开头

### DIFF
--- a/src/hooks/useApplying/utils.ts
+++ b/src/hooks/useApplying/utils.ts
@@ -26,8 +26,7 @@ export function rangeMatch(
     }
 
     // 如果输入有两个数字的情况
-    let inputReg = /^(\d+)(?:-(\d+))?/;
-    let inputMatch = input.match(inputReg);
+    let inputMatch = input.match(reg);
     if (inputMatch) {
       let inputStart = parseInt(inputMatch[1]);
       let inputEnd = parseInt(inputMatch[2] || inputMatch[1]);


### PR DESCRIPTION
页面上的薪资输入示例有点歧义，实际上输入【10-30】，源代码上匹配是必须是以数字开头导致匹配不上。
<img width="512" alt="image" src="https://github.com/user-attachments/assets/20169013-8ca5-4c2d-ba95-8475debe97bb" />
