### PR TITLE
feat: 添加将pipeline处理结果缓存到local的功能

### DIFF
--- a/src/composables/usePipelineCache.ts
+++ b/src/composables/usePipelineCache.ts
@@ -1,0 +1,241 @@
+import type { JobStatus } from '@/stores/jobs'
+import type {
+  PipelineCache,
+  PipelineCacheConfig,
+  PipelineCacheItem,
+  ProcessorType,
+} from '@/types/pipelineCache'
+import { jsonClone } from '@/utils/deepmerge'
+import { logger } from '@/utils/logger'
+import { getStorage, setStorage } from '@/utils/message/storage'
+import { ref } from 'vue'
+
+// 默认处理器配置
+const DEFAULT_PROCESSOR_CONFIGS: Record<ProcessorType, { expireTime: number }> = {
+  aiFiltering: { expireTime: 7 * 24 * 60 * 60 * 1000 }, // 7天
+  amap: { expireTime: 5 * 24 * 60 * 60 * 1000 }, // 5天
+  basic: { expireTime: 3 * 24 * 60 * 60 * 1000 }, // 3天
+}
+
+/**
+ * Pipeline缓存管理器
+ */
+export class PipelineCacheManager {
+  private cache = ref<PipelineCache>({
+    data: {},
+    lastCleanup: Date.now(),
+  })
+
+  private config: Required<PipelineCacheConfig>
+
+  constructor(config: PipelineCacheConfig = {}) {
+    this.config = {
+      expireDays: config.expireDays ?? 3,
+      cleanupInterval: config.cleanupInterval ?? 6 * 60 * 60 * 1000, // 6小时
+      storageKey: config.storageKey ?? 'local:pipeline-cache',
+      maxCacheSize: config.maxCacheSize ?? 10000,
+      processorConfigs: config.processorConfigs ?? DEFAULT_PROCESSOR_CONFIGS,
+    }
+
+    void this.initCache()
+  }
+
+  /**
+   * 初始化缓存，从存储加载数据
+   */
+  private async initCache() {
+    try {
+      const cached = await getStorage<PipelineCache | null>(this.config.storageKey, null)
+      if (cached) {
+        this.cache.value = cached
+        logger.debug('缓存数据加载成功', {
+          total: Object.keys(cached.data).length,
+        })
+      }
+      // 检查是否需要清理过期数据
+      await this.cleanupIfNeeded()
+      await this.evictLRUIfNeeded()
+    }
+    catch (error) {
+      logger.error('初始化缓存失败', error)
+    }
+  }
+
+  /**
+   * 根据消息内容推断处理器类型
+   */
+  private inferProcessorType(message: string): ProcessorType {
+    if (message.includes('AI') || message.includes('分数')) {
+      return 'aiFiltering'
+    }
+    if (message.includes('地址') || message.includes('距离') || message.includes('地图')) {
+      return 'amap'
+    }
+    return 'basic'
+  }
+
+  /**
+   * 检查缓存是否有效
+   */
+  isValidCache(encryptJobId: string): boolean {
+    const item = this.cache.value.data[encryptJobId]
+    if (!item)
+      return false
+
+    // 检查是否过期
+    if (Date.now() > item.expireAt) {
+      logger.debug('缓存已过期', { encryptJobId })
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * 获取缓存结果
+   */
+  getCachedResult(encryptJobId: string): PipelineCacheItem | null {
+    const item = this.cache.value.data[encryptJobId]
+    if (!item || Date.now() > item.expireAt) {
+      if (item) {
+        delete this.cache.value.data[encryptJobId]
+        void this.saveCache()
+      }
+      return null
+    }
+
+    // 更新LRU信息
+    item.lastAccessed = Date.now()
+    item.hitCount++
+
+    logger.debug('当前职位缓存命中次数', {
+      currentName: `${item.brandName} - ${item.jobName}`,
+      count: item.hitCount,
+    })
+
+    void this.saveCache()
+    return item
+  }
+
+  /**
+   * 设置缓存结果
+   */
+  async setCacheResult(
+    encryptJobId: string,
+    jobName: string,
+    brandName: string,
+    status: JobStatus,
+    message: string,
+    processorType?: ProcessorType,
+  ): Promise<void> {
+    try {
+      const now = Date.now()
+      const inferredProcessorType = processorType || this.inferProcessorType(message)
+      const processorConfig = this.config.processorConfigs[inferredProcessorType]
+      const expireAt = now + processorConfig.expireTime
+
+      const cacheItem: PipelineCacheItem = {
+        encryptJobId,
+        jobName,
+        brandName,
+        status,
+        message,
+        expireAt,
+        createdAt: now,
+        lastAccessed: now,
+        hitCount: 0,
+        processorType: inferredProcessorType,
+      }
+
+      this.cache.value.data[encryptJobId] = jsonClone(cacheItem)
+
+      logger.debug('缓存结果已保存', {
+        encryptJobId,
+        jobName,
+        processorType: inferredProcessorType,
+      })
+
+      await this.evictLRUIfNeeded()
+      await this.saveCache()
+    }
+    catch (error) {
+      logger.error('保存缓存结果失败', error)
+    }
+  }
+
+  /**
+   * 保存缓存到存储
+   */
+  private async saveCache(): Promise<void> {
+    try {
+      const cacheData = jsonClone(this.cache.value)
+      await setStorage(this.config.storageKey, cacheData)
+    }
+    catch (error) {
+      logger.error('保存缓存到存储失败', error)
+    }
+  }
+
+  /**
+   * 清理过期数据
+   */
+  private async cleanupExpired(): Promise<void> {
+    const now = Date.now()
+    const data = this.cache.value.data
+    let expiredCount = 0
+
+    for (const [key, item] of Object.entries(data)) {
+      if (now > item.expireAt) {
+        delete data[key]
+        expiredCount++
+      }
+    }
+
+    if (expiredCount > 0) {
+      this.cache.value.lastCleanup = now
+      await this.saveCache()
+      logger.info('清理过期缓存完成', { expiredCount })
+    }
+  }
+
+  /**
+   * LRU淘汰机制 - 当缓存数量超过最大限制时淘汰最少使用的缓存
+   */
+  private async evictLRUIfNeeded(): Promise<void> {
+    const data = this.cache.value.data
+    const cacheCount = Object.keys(data).length
+
+    if (cacheCount <= this.config.maxCacheSize) {
+      return
+    }
+
+    const evictCount = cacheCount - this.config.maxCacheSize
+    const items = Object.values(data).sort((a, b) => a.lastAccessed - b.lastAccessed)
+
+    for (let i = 0; i < evictCount; i++) {
+      delete data[items[i].encryptJobId]
+    }
+
+    logger.info('LRU淘汰完成', { evicted: evictCount })
+    await this.saveCache()
+  }
+
+  /**
+   * 如果需要则清理过期数据
+   */
+  private async cleanupIfNeeded(): Promise<void> {
+    const now = Date.now()
+    if (now - this.cache.value.lastCleanup > this.config.cleanupInterval) {
+      logger.debug('开始清理过期缓存')
+      await this.cleanupExpired()
+    }
+  }
+
+  /**
+   * 清空所有缓存
+   */
+  async clearCache(): Promise<void> {
+    this.cache.value.data = {}
+    await this.saveCache()
+  }
+}

--- a/src/pages/zhipin/hooks/useDeliver.ts
+++ b/src/pages/zhipin/hooks/useDeliver.ts
@@ -1,6 +1,6 @@
 import type { MyJobListData } from '@/stores/jobs'
 import type { logData, logErr } from '@/stores/log'
-import { createHandle, sendPublishReq } from '@/composables/useApplying'
+import { cachePipelineResult, createHandle, sendPublishReq } from '@/composables/useApplying'
 import { useCommon } from '@/composables/useCommon'
 
 import { useStatistics } from '@/composables/useStatistics'
@@ -96,6 +96,20 @@ export const useDeliver = defineStore('zhipin/deliver', () => {
         ElMessage.error('未知报错')
       }
       finally {
+        // 缓存Pipeline处理结果
+        try {
+          await cachePipelineResult(
+            data.encryptJobId,
+            data.jobName || '',
+            data.brandName || '',
+            data.status.status,
+            data.status.msg || '处理完成',
+          )
+        }
+        catch (cacheError) {
+          logger.warn('缓存Pipeline结果失败', cacheError)
+        }
+
         statistics.todayData.total++
         await delay(conf.formData.delay.deliveryInterval)
       }

--- a/src/stores/jobs.ts
+++ b/src/stores/jobs.ts
@@ -1,3 +1,4 @@
+import { checkJobCache } from '@/composables/useApplying'
 import { requestCard } from '@/composables/useApplying/utils'
 import { useHookVueData } from '@/composables/useVue'
 import { ref } from 'vue'
@@ -36,11 +37,14 @@ export class JobList {
         val = jobSet.get(item.encryptJobId)!
       }
       else {
+        // 检查缓存
+        const cacheCheck = checkJobCache(item.encryptJobId)
+
         val = {
           ...item,
           status: {
-            status: 'pending',
-            msg: '未开始',
+            status: cacheCheck.hasCache ? cacheCheck.cacheResult!.status : 'pending',
+            msg: cacheCheck.hasCache ? `${cacheCheck.cacheResult!.message} (缓存)` : '未开始',
             setStatus: (status: JobStatus, msg?: string) => {
               this._map[item.encryptJobId].status.status = status
               this._map[item.encryptJobId].status.msg = msg ?? ''

--- a/src/types/pipelineCache.ts
+++ b/src/types/pipelineCache.ts
@@ -1,0 +1,58 @@
+import type { JobStatus } from '@/stores/jobs'
+
+/**
+ * pipeline 处理分组类型
+ */
+export type ProcessorType = 'aiFiltering' | 'amap' | 'basic'
+
+/**
+ * Pipeline缓存项接口
+ */
+export interface PipelineCacheItem {
+  /** 职位唯一标识符 */
+  encryptJobId: string
+  /** 职位名称 */
+  jobName: string
+  /** 品牌名称 */
+  brandName: string
+  /** Pipeline执行结果状态 */
+  status: JobStatus
+  /** 状态描述信息 */
+  message: string
+  /** 过期时间戳 (毫秒) */
+  expireAt: number
+  /** 创建时间戳 (毫秒) */
+  createdAt: number
+  /** 最后访问时间戳 (毫秒) */
+  lastAccessed: number
+  /** 缓存命中次数 */
+  hitCount: number
+  /** 缓存分组 */
+  processorType: ProcessorType
+}
+
+/**
+ * Pipeline缓存存储结构
+ */
+export interface PipelineCache {
+  /** 缓存映射数据 */
+  data: Record<string, PipelineCacheItem>
+  /** 上次清理过期数据的时间戳 */
+  lastCleanup: number
+}
+
+/**
+ * Pipeline缓存配置
+ */
+export interface PipelineCacheConfig {
+  /** 缓存过期天数，默认3天 */
+  expireDays?: number
+  /** 清理间隔毫秒数，默认6小时 */
+  cleanupInterval?: number
+  /** 存储键名 */
+  storageKey?: string
+  /** 最大缓存数量,默认为1000 */
+  maxCacheSize?: number
+  /** 缓存分组配置 */
+  processorConfigs?: Record<ProcessorType, { expireTime: number }>
+}


### PR DESCRIPTION
## 问题现象：
很多时候boos获取的列表都是重复的职位，ai筛选后的也会重复推荐。
通过缓存pipeline已经计算后的结果，可以减少一些ai提交和添加一些统计信息。

## 新增的功能：
- 按照类型分级缓存（ai的缓存7天，地图5天，普通的筛选3天）
- 最大存储1000个，并自动过期清理
- 在职位列表显示缓存状态
- 添加缓存命中统计和调试日志  
