### PR TITLE
🐞 fix: 修复翻页判定

### DIFF
--- a/src/pages/zhipin/components/Statistics.vue
+++ b/src/pages/zhipin/components/Statistics.vue
@@ -80,15 +80,18 @@ async function startBatch() {
   try {
     logger.debug('start batch', page)
     let oldLen = 0
+    let oldFirstJobId = ''
     while (page.value.page <= 10 && !common.deliverStop) {
       await delay(conf.formData.delay.deliveryStarts)
       if (jobList._list.value.length === 0) {
         break
       }
-      else if ((location.href.includes('/web/geek/job-recommend') || location.href.includes('/web/geek/jobs')) && oldLen === jobList._list.value.length) {
+      const currentFirstJobId = jobList._list.value[0]?.encryptJobId ?? ''
+      if ((location.href.includes('/web/geek/job-recommend') || location.href.includes('/web/geek/jobs')) && oldLen === jobList._list.value.length && oldFirstJobId === currentFirstJobId) {
         break
       }
       oldLen = jobList._list.value.length
+      oldFirstJobId = currentFirstJobId
       await deliver.jobListHandle()
       if (common.deliverStop) {
         break


### PR DESCRIPTION
# 修复 Boss 直聘自动投递分页停止的 Bug (Fixing Pagination Bug)
Resolves #83 

## 任务背景 (Background)
用户报告在进行“批量投递”时，每次获取大约 **15条岗位信息** 之后脚本就会自动停止工作。

## 根本原因 (Root Cause)
通过分析代码，在 [src/pages/zhipin/components/Statistics.vue](file:///Users/azure/Documents/boss_helper/boss_helper/src/pages/zhipin/components/Statistics.vue) 的 [startBatch](file:///Users/azure/Documents/boss_helper/boss_helper/src/pages/zhipin/components/Statistics.vue#77-118) 自动投递轮询循环中，判断“是否加载了新的一页”的条件单纯依靠了**数组长度变化**：
```typescript
else if ((location.href.includes('/web/geek/job-recommend') || location.href.includes('/web/geek/jobs')) && oldLen === jobList._list.value.length) {
  break
}
```
Boss直聘的推荐/职位页面在翻页加载数据时，其DOM结构可能会**替换**原有的列表（每次固定15条），而不是在原列表后继续**追加**。当由于替换导致新的一页长度仍然保持为 15 时：
- `oldLen` 为 15
- 加载后新的列表 `length` 仍是 15
- 条件 `15 === 15` 成立，导致脚本误认为“没有加载出新数据”，从而直接跳出了循环 (`break`)。这也精确解释了为何总是在 15 条左右时停止。

## 修复方案 (Solution)
为了兼容“追加”和“替换”两种翻页逻辑，我们在循环中除了比对 `length`（列表长度）外，同时引入对 `第一条工作的 ID (oldFirstJobId)` 的比对作为验证机制。

只有当：
1. **列表长度未发生改变** 
2. 且 **列表第一项的数据也完全没变**

时，才被判定为“已到达底部/没有新数据加载”，才会跳出循环。我们已更新代码：
```diff
+      const currentFirstJobId = jobList._list.value[0]?.encryptJobId ?? ''
-      else if ((location.href.includes('/web/geek/job-recommend') || location.href.includes('/web/geek/jobs')) && oldLen === jobList._list.value.length) {
+      if ((location.href.includes('/web/geek/job-recommend') || location.href.includes('/web/geek/jobs')) && oldLen === jobList._list.value.length && oldFirstJobId === currentFirstJobId) {
         break
       }
       oldLen = jobList._list.value.length
+      oldFirstJobId = currentFirstJobId
```

## 测试与验证 (Verification Plan)
代码更新有效，无需额外的依赖安装：
1. 用户直接刷新含有 Boss直聘推荐岗位的页面（通常为 `/web/geek/job-recommend`）。
2. 点击“开始”自动投递，脚本遇到分页时将通过 [usePager().next()](file:///Users/azure/Documents/boss_helper/boss_helper/src/pages/zhipin/hooks/usePager.ts#28-45) 触发翻页。
3. 等待网络响应后，新条目会被赋予全新的 `encryptJobId`。由于 `oldFirstJobId !== currentFirstJobId`，自动投递此时不再错误停止，修复成功。
