### PR TITLE
fix: 修复构建错误和自定义招呼语图片发送问题

### DIFF
--- a/src/composables/useHelper/index.ts
+++ b/src/composables/useHelper/index.ts
@@ -2,7 +2,7 @@ import { inject, InjectionKey } from 'vue'
 
 import { HelperContext } from './ctx'
 export { HelperContext } from './ctx'
-export { JobBaseData, JobData, LogData, Log } from './type'
+export type { JobBaseData, JobData, LogData, Log } from './type'
 
 export const HelperKey = Symbol() as InjectionKey<HelperContext<any, unknown, unknown>>
 

--- a/src/entrypoints/boss/index.ts
+++ b/src/entrypoints/boss/index.ts
@@ -227,6 +227,8 @@ export class BossHelperCtx extends HelperContext<BossHelperCtx, BoosJobData, {}>
     }
     for (const msg of msgs) {
       var m
+      // Each chat message needs its own client id; reusing one makes later messages look duplicated.
+      stanza.clientMid = Date.now()
       if (msg.type === 'image') {
         const response = await counter.getImage(msg.image)
         if (!response.success) {

--- a/src/entrypoints/boss/inject.css
+++ b/src/entrypoints/boss/inject.css
@@ -87,27 +87,28 @@
     animation: coli2 0.3s linear infinite;
   }
 
-  @keyframes coli1 {
-    0% {
-      transform: rotate(-45deg) translateX(0px);
-      opacity: 0.7;
-    }
+}
 
-    100% {
-      transform: rotate(-45deg) translateX(-45px);
-      opacity: 0;
-    }
+@keyframes coli1 {
+  0% {
+    transform: rotate(-45deg) translateX(0px);
+    opacity: 0.7;
   }
 
-  @keyframes coli2 {
-    0% {
-      transform: rotate(45deg) translateX(0px);
-      opacity: 1;
-    }
+  100% {
+    transform: rotate(-45deg) translateX(-45px);
+    opacity: 0;
+  }
+}
 
-    100% {
-      transform: rotate(45deg) translateX(-45px);
-      opacity: 0.7;
-    }
+@keyframes coli2 {
+  0% {
+    transform: rotate(45deg) translateX(0px);
+    opacity: 1;
+  }
+
+  100% {
+    transform: rotate(45deg) translateX(-45px);
+    opacity: 0.7;
   }
 }

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -7,12 +7,10 @@
 
     <!-- Customize the manifest options -->
     <meta name="manifest.open_in_tab" content="true" />
-    <meta name="manifest.chrome_style" content="false" />
     <meta name="manifest.browser_style" content="false" />
 
     <!-- Set include/exclude if the page should be removed from some builds -->
     <meta name="manifest.include" content="['chrome', 'firefox']" />
-    <meta name="manifest.exclude" content="['chrome', 'firefox']" />
   </head>
   <body>
     <!-- ... -->


### PR DESCRIPTION
### 修复 pnpm build 构建失败问题
修复项目执行 pnpm build 时遇到的多个构建错误：
- 修复类型导出导致的 MISSING_EXPORT 错误
- 修复 LightningCSS 无法处理嵌套 @keyframes 的问题
- 移除 Chrome MV3 不支持的 chrome_style 配置
- 修复 options 页面 manifest 配置冲突


### 修复自定义招呼语无法连续发送图片的问题
修复自定义招呼语同时配置“文本 + 简历图片”时，只能发送第一条消息的问题。
原因是多条消息复用了相同的 clientMid，后续消息被聊天服务识别为重复消息。现在每条消息都会生成独立的 clientMid，可以正常连续发送：
- 文本消息
- 图片消息
- 文本 + 图片组合消息
已实际测试文本和简历图片同时发送，功能正常。

<img width="1723" height="1340" alt="test" src="https://github.com/user-attachments/assets/3f57098f-c645-46c5-a3a1-c4a8363cc12d" />