### PR TITLE
fix: 统计NaN、日志断链、AI模型配置与流式超时修复

### DIFF
--- a/src/components/AI/LLMForm.vue
+++ b/src/components/AI/LLMForm.vue
@@ -13,11 +13,19 @@ const enabledFields = reactive<Record<string, boolean>>({})
 
 const initializeEnabledFields = () => {
   const info = openai.info as unknown as LLMInfo<ModelConfData>
+  const formDataAny = formData.value as any
   for (const [key, item] of Object.entries(info)) {
     if (key === 'mode') continue
     const itemAny = item as any
-    if (!itemAny.required && formData.value[key as keyof ModelConfData] !== undefined) {
-      enabledFields[key] = true
+    // Enable field if it has a value OR has a default value OR is not required
+    if (!itemAny.required) {
+      if (formDataAny[key] !== undefined) {
+        enabledFields[key] = true
+      } else if (itemAny.value !== undefined) {
+        // Initialize with default value from info
+        formDataAny[key] = itemAny.value
+        enabledFields[key] = true
+      }
     }
   }
 }

--- a/src/components/AI/LLMFormItem.vue
+++ b/src/components/AI/LLMFormItem.vue
@@ -19,7 +19,10 @@ const fromVal = defineModel<any>({
 })
 
 const LLMFormRef = inject<Ref<HTMLDivElement>>('LLMFormRef')
-const isSetVal = ref(fromVal.value !== undefined)
+const isFieldInfo = computed(() => !('alert' in props.info))
+const infoF = computed(() => (isFieldInfo.value ? (props.info as LLMInfoValF<T, any>) : undefined))
+const isSetVal = ref(fromVal.value !== undefined || infoF.value?.value !== undefined)
+const isDisabled = computed(() => infoF.value?.config?.disabled === true)
 </script>
 
 <template>
@@ -56,16 +59,16 @@ const isSetVal = ref(fromVal.value !== undefined)
       >
     </template>
     <UCheckbox
-      v-if="info.config?.disabled || !info.required"
+      v-if="!info.required && !isDisabled"
       v-model="isSetVal"
       @update:model-value="
         (x) => {
           if (!x) fromVal = undefined
+          else if (fromVal === undefined && infoF?.value !== undefined) fromVal = infoF.value
         }
       "
-      :disable="info.config?.disabled"
     />
-    <template v-if="info.required || isSetVal">
+    <template v-if="info.required || isSetVal || isDisabled">
       <UInputNumber
         v-if="info.type === 'input' && info.format === 'number'"
         v-model="fromVal"

--- a/src/components/AI/LLMModelEdit.vue
+++ b/src/components/AI/LLMModelEdit.vue
@@ -31,7 +31,26 @@ const createColor = ref(props.model?.color || color16())
 const testShow = ref(false)
 
 const llmFormData = reactive(
-  props.model?.data ?? ({ mode: 'openai', advanced: {}, other: {} } as OpenaiLLMConf),
+  props.model?.data ??
+    ({
+      mode: 'openai',
+      avatar: '',
+      base_url: '',
+      api_key: '',
+      model: '',
+      responses: false,
+      other: { timeout: 18000 },
+      advanced: {
+        json: true,
+        stream: false,
+        temperature: undefined,
+        top_p: undefined,
+        presence_penalty: 0,
+        frequency_penalty: undefined,
+        extra_headers: undefined,
+        extra_body: undefined,
+      },
+    } as OpenaiLLMConf),
 )
 
 const testIn = ref('')
@@ -130,6 +149,9 @@ function create() {
   data.name = createName.value
   data.data = jsonClone(llmFormData) as ModelConf['data'] & {}
   data.data.mode = 'openai'
+  // Ensure other and advanced are at least empty objects
+  if (!data.data.other) data.data.other = { timeout: 18000 } as any
+  if (!data.data.advanced) data.data.advanced = {} as any
   data.color = createColor.value
   emit('create', data)
 }

--- a/src/components/AI/LLMModelManage.vue
+++ b/src/components/AI/LLMModelManage.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 
-import Alert from '@/components/Alert.vue'
+import { useConf } from '@/composables/conf'
 import type { ModelConf } from '@/composables/useModel'
 import { useModel } from '@/composables/useModel'
 import deepmerge, { jsonClone } from '@/utils/deepmerge'
@@ -10,16 +10,45 @@ import { exportJson, importJson } from '@/utils/jsonImportExport'
 import CreateLLM from './LLMModelEdit.vue'
 
 const modelStore = useModel()
+const conf = useConf()
 const createBoxShow = ref(false)
 const toast = useToast()
 const open = ref(false)
 
-function del(d: ModelConf) {
+async function del(d: ModelConf) {
   modelStore.modelData.value = modelStore.modelData.value.filter((v) => d.key !== v.key)
-  toast.add({
-    title: '删除成功',
-    color: 'success',
-  })
+
+  for (const key of ['aiFiltering', 'aiGreeting', 'aiReply'] as const) {
+    const aiConfig = conf.formData[key]
+    if (aiConfig?.model === d.key) {
+      aiConfig.model = undefined
+      aiConfig.enable = false
+    }
+  }
+  if (conf.formData.record.model?.includes(d.key)) {
+    conf.formData.record.model = conf.formData.record.model.filter((key) => key !== d.key)
+  }
+
+  try {
+    await Promise.all([modelStore.persistModel(), conf.persistFormData()])
+    toast.add({
+      title: '模型已删除，相关 AI 功能已停用',
+      color: 'success',
+    })
+  } catch (error: any) {
+    const msg = String(error?.message || error)
+    if (msg.includes('context invalidated') || msg.includes('Extension context')) {
+      toast.add({
+        title: '扩展已更新，请刷新页面后重试',
+        color: 'warning',
+      })
+    } else {
+      toast.add({
+        title: `删除失败: ${msg}`,
+        color: 'error',
+      })
+    }
+  }
 }
 
 function copy(d: ModelConf) {
@@ -63,6 +92,25 @@ function create(d: ModelConf) {
 function close() {
   modelStore.initModel()
   open.value = false
+}
+
+async function save() {
+  try {
+    await modelStore.saveModel()
+  } catch (error: any) {
+    const msg = String(error?.message || error)
+    if (msg.includes('context invalidated') || msg.includes('Extension context')) {
+      toast.add({
+        title: '扩展已更新，请刷新页面后重试',
+        color: 'warning',
+      })
+    } else {
+      toast.add({
+        title: `保存失败: ${msg}`,
+        color: 'error',
+      })
+    }
+  }
 }
 
 function exportllm() {
@@ -138,7 +186,7 @@ function importllm() {
         <UButton color="success" @click="exportllm"> 导出 </UButton>
         <UButton color="success" @click="importllm"> 导入 </UButton>
         <UButton @click="newllm"> 新建 </UButton>
-        <UButton @click="modelStore.saveModel"> 保存 </UButton>
+        <UButton @click="save"> 保存 </UButton>
       </div>
     </template>
   </UModal>

--- a/src/components/Tabs/Logs.vue
+++ b/src/components/Tabs/Logs.vue
@@ -1,9 +1,11 @@
 <script lang="tsx" setup>
 import { reactive, ref } from 'vue'
 
-import JobCard from '@/components/JobCard.vue'
 import { TableColumn } from '@nuxt/ui'
-import { useHelper,Log } from '@/composables/useHelper'
+
+import JobCard from '@/components/JobCard.vue'
+import { Log, useHelper } from '@/composables/useHelper'
+
 const helper = useHelper()
 
 // const { filterData, dialogData } = useLog()
@@ -13,29 +15,50 @@ const dialogData = reactive<{ show: boolean; data?: Log }>({ show: false })
 const aiFilterActiveNames = ref('response')
 const aiGreetActiveNames = ref('response')
 
+const stateColors = {
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+  danger: 'error',
+} as const
+
 const columns: TableColumn<Log>[] = [
   {
-    accessorKey: 'level',
+    accessorKey: 'time',
+    header: '时间',
+  },
+  {
+    accessorKey: 'state_name',
     header: '级别',
-    // width: 200,
+    cell: ({ row }) => (
+      <UBadge color={stateColors[row.original.state]}>{row.original.state_name}</UBadge>
+    ),
+  },
+  {
+    accessorKey: 'company',
+    header: '公司',
+    cell: ({ row }) => <span>{row.original.job?.brand?.name ?? '-'}</span>,
+  },
+  {
+    accessorKey: 'salary',
+    header: '薪酬',
+    cell: ({ row }) => <span>{row.original.job?.salary ?? '-'}</span>,
+  },
+  {
+    accessorKey: 'title',
+    header: '内容',
     cell: ({ row }) => (
       <UButton
+        color="neutral"
+        variant="link"
         onClick={() => {
           dialogData.show = true
           dialogData.data = row.original
         }}
       >
-        {row.getValue('title')}
+        {row.original.title}
+        {row.original.message ? `：${row.original.message}` : ''}
       </UButton>
-    ),
-  },
-  {
-    accessorKey: 'state',
-    header: '内容',
-    // width: 150,
-    // align: 'center',
-    cell: ({ row }) => (
-      <UBadge color={row.getValue('state') ?? 'primary'}>{row.getValue('state_name')}</UBadge>
     ),
     // headerCellRenderer: (props: HeaderCellRendererParams<log>) => {
     //   return (
@@ -107,8 +130,24 @@ const columns: TableColumn<Log>[] = [
 </script>
 
 <template>
-  <h1>维护当中...还没想好如何设计</h1>
-  <UTable ref="tableRef" :columns="columns" :data="helper.logs.value" :height="360" />
+  <div class="flex items-center justify-between mb-2">
+    <div class="text-sm text-muted">共 {{ helper.logs.value.length }} 条运行日志</div>
+    <UButton
+      icon="i-lucide-trash-2"
+      color="neutral"
+      variant="outline"
+      size="sm"
+      :disabled="helper.logs.value.length === 0"
+      @click="helper.logs.clear()"
+    >
+      清空
+    </UButton>
+  </div>
+  <UTable ref="tableRef" :columns="columns" :data="helper.logs.value" :height="360">
+    <template #empty>
+      <div class="py-10 text-center text-muted">暂无运行日志，开始处理岗位后会显示在这里</div>
+    </template>
+  </UTable>
   <UModal v-model:open="dialogData.show" title="日志详情">
     <template #body>
       <div class="log-detail">
@@ -118,44 +157,24 @@ const columns: TableColumn<Log>[] = [
         <div class="log-detail-right">
           <UTabs class="demo-tabs">
             <UTabsList>
-              <UTabsTrigger v-if="dialogData.data?.data?.aiFilteringQ" value="first"
+              <UTabsTrigger v-if="dialogData.data?.data?.aiFilteringAtext" value="first"
                 >AI过滤</UTabsTrigger
               >
-              <UTabsTrigger v-if="dialogData.data?.data?.aiGreetingQ" value="second"
-                >AI打招呼</UTabsTrigger
+              <UTabsTrigger v-if="dialogData.data?.data?.aiGreetingA" value="second"
+                >AI招呼语</UTabsTrigger
               >
               <UTabsTrigger v-if="dialogData.data?.data?.err" value="fourth">错误信息</UTabsTrigger>
             </UTabsList>
-            <UTabsContent v-if="dialogData.data?.data?.aiFilteringQ" value="first">
+            <UTabsContent v-if="dialogData.data?.data?.aiFilteringAtext" value="first">
               <UAccordion v-model="aiFilterActiveNames" type="single" collapsible>
-                <UAccordionItem value="prompt" title="Prompt">
-                  <div class="ai-text">{{ dialogData.data.data.aiFilteringQ }}</div>
-                </UAccordionItem>
-                <UAccordionItem
-                  v-if="dialogData.data.data.aiFilteringR"
-                  value="thinking"
-                  title="思考过程"
-                >
-                  <div class="ai-text">{{ dialogData.data.data.aiFilteringR }}</div>
-                </UAccordionItem>
-                <UAccordionItem value="response" title="响应" class="active">
+                <UAccordionItem value="response" title="AI过滤结果" class="active">
                   <div class="ai-text">{{ dialogData.data.data.aiFilteringAtext }}</div>
                 </UAccordionItem>
               </UAccordion>
             </UTabsContent>
-            <UTabsContent v-if="dialogData.data?.data?.aiGreetingQ" value="second">
+            <UTabsContent v-if="dialogData.data?.data?.aiGreetingA" value="second">
               <UAccordion v-model="aiGreetActiveNames" type="single" collapsible>
-                <UAccordionItem value="prompt" title="Prompt">
-                  <div class="ai-text">{{ dialogData.data.data.aiGreetingQ }}</div>
-                </UAccordionItem>
-                <UAccordionItem
-                  v-if="dialogData.data.data.aiGreetingR"
-                  value="thinking"
-                  title="思考过程"
-                >
-                  <div class="ai-text">{{ dialogData.data.data.aiGreetingR }}</div>
-                </UAccordionItem>
-                <UAccordionItem value="response" title="响应" class="active">
+                <UAccordionItem value="response" title="AI招呼语" class="active">
                   <div class="ai-text">{{ dialogData.data.data.aiGreetingA }}</div>
                 </UAccordionItem>
               </UAccordion>

--- a/src/components/Tabs/Statistics.vue
+++ b/src/components/Tabs/Statistics.vue
@@ -4,11 +4,10 @@ import { computed, onMounted, ref } from 'vue'
 import Alert from '@/components/Alert.vue'
 import { useConf } from '@/composables/conf'
 import { useHelper } from '@/composables/useHelper'
-import { useStatistics } from '@/composables/useStatistics'
 
 const ctx = useHelper()
 
-const statistics = useStatistics()
+const statistics = ctx.statistics
 
 // const { next, page } = usePager()
 const conf = useConf()
@@ -55,6 +54,11 @@ const deliveryLimit = computed(() => {
   return conf.formData.deliveryLimit.value
 })
 
+function percentage(value: number) {
+  if (statistics.todayData.total <= 0) return '0.0'
+  return ((value / statistics.todayData.total) * 100).toFixed(1)
+}
+
 onMounted(() => {
   statistics.updateStatistics()
 })
@@ -78,34 +82,21 @@ onMounted(() => {
       <div data-help="统计当天岗位过滤的比例,被过滤/总数">
         <div class="text-sm text-gray-500">过滤比例：</div>
         <div class="text-2xl font-semibold">
-          {{
-            (
-              ((statistics.todayData.total - statistics.todayData.success) /
-                statistics.todayData.total) *
-              deliveryLimit
-            ).toFixed(1)
-          }}
+          {{ percentage(statistics.todayData.total - statistics.todayData.success) }}
           <span class="text-sm text-gray-400">%</span>
         </div>
       </div>
       <div data-help="统计当天刷到了多少处理过的岗位,重复/总数">
         <div class="text-sm text-gray-500">重复比例：</div>
         <div class="text-2xl font-semibold">
-          {{
-            ((statistics.todayData.repeat / statistics.todayData.total) * deliveryLimit).toFixed(1)
-          }}
+          {{ percentage(statistics.todayData.repeat) }}
           <span class="text-sm text-gray-400">%</span>
         </div>
       </div>
       <div data-help="统计当天岗位中的活跃情况,不活跃/总数">
         <div class="text-sm text-gray-500">活跃比例：</div>
         <div class="text-2xl font-semibold">
-          {{
-            (
-              (statistics.todayData.activityFilter / statistics.todayData.total) *
-              deliveryLimit
-            ).toFixed(1)
-          }}
+          {{ percentage(statistics.todayData.activityFilter) }}
           <span class="text-sm text-gray-400">%</span>
         </div>
       </div>

--- a/src/composables/conf/index.ts
+++ b/src/composables/conf/index.ts
@@ -183,17 +183,21 @@ export const useConf = () => {
     }
   }
 
+  async function persistFormData() {
+    const v = jsonClone(formData)
+    await counter.storageSet(formDataKey(), v)
+    await counter.storageSet(formDataPresetKey, formDataPreset.value)
+    await counter.storageSet(formDataPresetsKey, formDataPresets.value)
+  }
+
   async function confSaving() {
     try {
-      await counter.storageSet(formDataKey(), jsonClone(formData))
-      await counter.storageSet(formDataPresetKey, jsonClone(formDataPreset.value))
-      await counter.storageSet(formDataPresetsKey, jsonClone(formDataPresets.value))
-
+      await persistFormData()
+      logger.debug('formData保存', jsonClone(formData))
       toast.add({
         title: '保存成功',
         color: 'success',
       })
-      logger.debug('formData保存')
     } catch (error: any) {
       toast.add({
         title: `保存失败: ${error.message}`,
@@ -332,6 +336,7 @@ export const useConf = () => {
   return {
     confInit: init,
     confSaving,
+    persistFormData,
     confReload,
     confExport,
     confImport,

--- a/src/composables/useApplying/handles.ts
+++ b/src/composables/useApplying/handles.ts
@@ -354,8 +354,15 @@ export class TaskRegistry<C extends HelperContext<C, T, S>, T, S = {}> {
         throw new HelperConfigError('aiFiltering.model', 'AI筛选模型未配置')
       }
       return async (ctx, data) => {
-        const content = await ctx.helper.chatModel.chat('filtering', data).then((r) => r.text)
+        const stream = await ctx.helper.chatModel.chat('filtering', data)
+        const content = (await stream.text) ?? ''
+        if (!content) {
+          return taskResult.skip('AI 返回内容为空')
+        }
         const { message, rating } = parseFiltering(content)
+        data.state.aiFilteringAtext = content
+        data.state.aiFilteringRating = rating
+        data.state.aiFilteringMessage = message
         if (rating < (ctx.helper.conf.formData.aiFiltering.score ?? 10)) {
           return taskResult.skip(message)
         }
@@ -392,9 +399,12 @@ export class TaskRegistry<C extends HelperContext<C, T, S>, T, S = {}> {
   })
 
   customGreeting = defineTaskHandler<C, T, S>(
-    '打招呼',
+    '自定义招呼语',
     (ctx) => {
-      if (!ctx.helper.conf.formData.customGreeting.enable) {
+      if (
+        !ctx.helper.conf.formData.customGreeting.enable ||
+        ctx.helper.conf.formData.aiGreeting.enable
+      ) {
         return
       }
       return async (ctx, data) => {
@@ -439,7 +449,7 @@ export class TaskRegistry<C extends HelperContext<C, T, S>, T, S = {}> {
   )
 
   aiGreeting = defineTaskHandler<C, T, S>(
-    '打招呼',
+    'AI招呼语',
     (ctx) => {
       if (!ctx.helper.conf.formData.aiGreeting.enable) {
         return
@@ -448,7 +458,12 @@ export class TaskRegistry<C extends HelperContext<C, T, S>, T, S = {}> {
         throw new HelperConfigError('aiGreeting.model', 'AI招呼模型未配置')
       }
       return async (ctx, data) => {
-        const msg = await ctx.helper.chatModel.chat('greetings', data).then((r) => r.text)
+        const stream = await ctx.helper.chatModel.chat('greetings', data)
+        const msg = (await stream.text) ?? ''
+        if (!msg) {
+          return taskResult.skip('AI 招呼语为空')
+        }
+        data.state.aiGreetingA = msg
         await ctx.helper.sendMessage?.(data, msg)
       }
     },

--- a/src/composables/useApplying/index.ts
+++ b/src/composables/useApplying/index.ts
@@ -1,5 +1,6 @@
 import { shallowRef, ref } from 'vue'
 
+import { BossHelperError } from '@/composables/useApplying/deliverError'
 import { PipelineCacheManager } from '@/composables/usePipelineCache'
 import type { PipelineCacheItem, ProcessorType } from '@/types/pipelineCache'
 
@@ -63,7 +64,7 @@ export type DeliveryWorkflow<C extends HelperContext<C, T, S>, T, S> = Awaited<
 >
 
 function meginResults(res: void | TaskResult | Array<TaskResult | void>): TaskResult | void {
-  if (!res) return
+  if (!res) return {}
   if (Array.isArray(res)) {
     if (res.length === 0) return
     return res.reduce((acc: TaskResult, r) => {
@@ -77,7 +78,6 @@ function meginResults(res: void | TaskResult | Array<TaskResult | void>): TaskRe
         }
       }
       return {
-        id: acc.id || r.id,
         isSkip: acc.isSkip || r.isSkip,
         reason: [acc.reason, r.reason].filter(Boolean).join('\n') || undefined,
         status: mergedStatus,
@@ -109,6 +109,7 @@ export async function useDeliveryWorkflow<C extends HelperContext<C, T, S>, T, S
   >([])
   const stateMaps = ref(new Map<string, any>())
   const resolvedHandlers = new Map<string, Handler<C, T, S>>()
+  const countedJobs = new Set<string>()
 
   const rebuild = async () => {
     const _ctx: TaskContext<C, T, S> = { helper, now: new Date() }
@@ -230,6 +231,9 @@ export async function useDeliveryWorkflow<C extends HelperContext<C, T, S>, T, S
 
   const execute = async (data: WorkflowData<T, S>) => {
     const isStop = () => status.value === 'stop'
+    let finalTaskId: string | undefined
+    let finalResult: TaskResult | undefined
+    let delivered = false
     try {
       let skipPipeline = false
       for (const t of pipeline.value) {
@@ -242,8 +246,11 @@ export async function useDeliveryWorkflow<C extends HelperContext<C, T, S>, T, S
           })
           res = await executeTask(t, data)
           if (res != null) {
+            finalTaskId = t.id
+            finalResult = res
             res.msg ??= t.label ?? t.id
             res.status ??= res.isSkip ? 'warn' : undefined
+            if (t.id === '岗位投递' && res.status === 'success') delivered = true
             if (res.isSkip) {
               skipPipeline = true
               break
@@ -257,6 +264,8 @@ export async function useDeliveryWorkflow<C extends HelperContext<C, T, S>, T, S
             reason: `任务${t.label ?? t.id}执行失败: ${e instanceof Error ? e.message : e}`,
             msg: `报错/${t.label ?? t.id}`,
           }
+          finalTaskId = t.id
+          finalResult = res
           logger.error(`任务${t.label ?? t.id}执行失败`, e)
           skipPipeline = true
           break
@@ -279,6 +288,39 @@ export async function useDeliveryWorkflow<C extends HelperContext<C, T, S>, T, S
           status: 'success',
           msg: '投递成功',
         })
+      }
+
+      if (!isStop() && !countedJobs.has(data.jobData.key)) {
+        countedJobs.add(data.jobData.key)
+        helper.statistics.todayData.total += 1
+        if (delivered || !skipPipeline) helper.statistics.todayData.success += 1
+        if (finalResult?.isCache || finalTaskId?.startsWith('重复沟通-')) {
+          helper.statistics.todayData.repeat += 1
+        }
+        if (finalResult?.isSkip && finalTaskId === '活跃度过滤') {
+          helper.statistics.todayData.activityFilter += 1
+        }
+
+        if (finalResult?.isSkip) {
+          const logError = new BossHelperError(
+            finalResult.reason ?? finalResult.msg ?? '岗位已过滤',
+            finalResult.status === 'error' ? 'danger' : 'warning',
+          )
+          logError.name = finalResult.status === 'error' ? '处理出错' : '已过滤'
+          helper.logs.add(data.jobData, logError, {
+            jobData: data.jobData,
+            aiFilteringAtext: data.state.aiFilteringAtext,
+            aiGreetingA: data.state.aiGreetingA,
+            err: finalResult.status === 'error' ? finalResult.reason : undefined,
+            message: finalResult.reason,
+          })
+        } else {
+          helper.logs.add(data.jobData, undefined, {
+            jobData: data.jobData,
+            aiFilteringAtext: data.state.aiFilteringAtext,
+            aiGreetingA: data.state.aiGreetingA,
+          })
+        }
       }
     } catch (e) {
       status.value = 'error'

--- a/src/composables/useApplying/type.ts
+++ b/src/composables/useApplying/type.ts
@@ -42,6 +42,10 @@ export interface WorkflowState {
     geocode?: Awaited<ReturnType<typeof amapGeocode>>
     distance?: Awaited<ReturnType<typeof amapDistance>>
   }
+  aiFilteringAtext?: string
+  aiFilteringRating?: number
+  aiFilteringMessage?: string
+  aiGreetingA?: string
 }
 
 export interface WorkflowData<T, S> {
@@ -56,7 +60,6 @@ export type TaskResult = {
   status?: JobStatus
   msg?: string
   isCache?: boolean
-  id?: string
 }
 
 export type Handler<C extends HelperContext<C, T, S>, T, S> = (

--- a/src/composables/useApplying/utils.ts
+++ b/src/composables/useApplying/utils.ts
@@ -40,23 +40,34 @@ export function parseFiltering(content: string) {
     reason: string
     score: number
   }
+
   const res = parseGptJson<{
-    negative: Item[]
-    positive: Item[]
+    negative?: Item[] | string
+    positive?: Item[] | string
+    rating?: number
+    message?: string
   }>(content)
 
-  const hand = (acc: { score: number; reason: string }, curr: Item) => ({
-    score: acc.score + Math.abs(curr.score),
-    reason: `${acc.reason}\n${curr.reason}/(${Math.abs(curr.score)}分)`,
-  })
-  const data = {
-    negative: res?.negative?.reduce(hand, { score: 0, reason: '' }),
-    positive: res?.positive?.reduce(hand, { score: 0, reason: '' }),
+  const toItems = (val: any): Item[] => {
+    if (Array.isArray(val)) return val
+    if (typeof val === 'string' && val) return [{ reason: val, score: 0 }]
+    return []
   }
 
-  const rating = (data?.positive?.score ?? 0) - (data?.negative?.score ?? 0)
+  const hand = (acc: { score: number; reason: string }, curr: Item) => ({
+    score: acc.score + (Math.abs(Number(curr.score)) || 0),
+    reason: `${acc.reason}\n${curr.reason ?? ''}/(${Math.abs(Number(curr.score)) || 0}分)`,
+  })
 
-  const message = `分数${rating}\n消极:${data?.negative?.reason}\n\n积极:${data?.positive?.reason}`
+  const negItems = toItems(res?.negative)
+  const posItems = toItems(res?.positive)
 
-  return { res, message, rating, data }
+  const neg = negItems.reduce(hand, { score: 0, reason: '' })
+  const pos = posItems.reduce(hand, { score: 0, reason: '' })
+
+  const rating = res?.rating ?? pos.score - neg.score
+
+  const message = res?.message ?? `分数${rating}\n消极:${neg.reason}\n\n积极:${pos.reason}`
+
+  return { res, message, rating, data: { negative: neg, positive: pos } }
 }

--- a/src/composables/useHelper/ctx.ts
+++ b/src/composables/useHelper/ctx.ts
@@ -37,9 +37,8 @@ export abstract class HelperContext<C extends HelperContext<C, T, S>, T, S> {
     clear: () => void
     value: Log[]
   }
-  pendingMessages: Ref<string | undefined>
+
   constructor() {
-    this.pendingMessages = ref()
     this.conf = useConf()
     this.models = useModel()
     this.statistics = useStatistics()
@@ -49,8 +48,10 @@ export abstract class HelperContext<C extends HelperContext<C, T, S>, T, S> {
       add: (job: JobData, err?: BossHelperError, logdata?: LogData, msg?: string) => {
         const state = !err ? 'success' : err.state
         const message = msg ?? (err ? err.message : undefined)
+        if (this._logs.value.length >= 500) this._logs.value.shift()
         this._logs.value.push({
           job,
+          time: new Date().toLocaleTimeString(),
           title: job.jobName,
           state,
           state_name: err?.name ?? '投递成功',
@@ -59,7 +60,9 @@ export abstract class HelperContext<C extends HelperContext<C, T, S>, T, S> {
         })
       },
       info: (title: string, message: string) => {
+        if (this._logs.value.length >= 500) this._logs.value.shift()
         this._logs.value.push({
+          time: new Date().toLocaleTimeString(),
           title,
           state: 'info',
           state_name: '消息',

--- a/src/composables/useHelper/type.ts
+++ b/src/composables/useHelper/type.ts
@@ -116,6 +116,7 @@ type logState = 'info' | 'success' | 'warning' | 'danger'
 
 export interface Log {
   job?: JobData
+  time: string
   title: string // 标题
   state: logState // 信息,成功,过滤,出错
   state_name: string // 标签文本

--- a/src/composables/useModel/chatModel.ts
+++ b/src/composables/useModel/chatModel.ts
@@ -1,4 +1,3 @@
-import { createOpenAI, OpenAIProvider } from '@ai-sdk/openai'
 import { ChatMessageProps } from '@nuxt/ui'
 import {
   APICallError,
@@ -20,6 +19,7 @@ import { renderTemplate } from '@/utils/ai'
 import { ModelConf } from '.'
 import { WorkflowData } from '../useApplying/type'
 import { HelperContext } from '../useHelper'
+import { openai } from './openai'
 
 const role = ['system', 'user', 'assistant', 'boss', 'jd', 'filtering', 'greetings'] as const
 type MessageRole = (typeof role)[number]
@@ -86,7 +86,6 @@ export class ChatModel {
 
   jobs = ref<string[]>([])
 
-  providers: Map<string, OpenAIProvider> = new Map()
   agents: Map<MessageRole, [ToolLoopAgent, ModelConf, FormDataAi]> = new Map()
   generateId: { [key in MessageRole]: () => string }
 
@@ -114,19 +113,17 @@ export class ChatModel {
     if (!conf || !model.model) {
       return false
     }
-    let provider = this.providers.get(model.model)
-    if (!provider) {
-      provider = createOpenAI({
-        baseURL: conf.data?.base_url,
-        apiKey: conf.data?.api_key,
-      })
-    }
-    this.providers.set(model.model, provider)
+    if (!conf.data) return false
 
+    const advanced = conf.data.advanced ?? {}
     const agent = new ToolLoopAgent({
-      model: provider.chat(conf.data?.model || 'gpt-4o'),
+      model: openai.createModel(conf.data),
       output: opt?.json ? Output.json() : Output.text(),
       allowSystemInMessages: true,
+      temperature: advanced.temperature,
+      topP: advanced.top_p,
+      presencePenalty: advanced.presence_penalty,
+      frequencyPenalty: advanced.frequency_penalty,
     })
     this.agents.set(name, [agent, conf, model])
     return true
@@ -148,7 +145,8 @@ export class ChatModel {
 
     const [agent, modelConf, model] = _agent
 
-    const timeout = modelConf.data?.other?.timeout ?? 60000
+    const idleTimeout = modelConf.data?.other?.timeout ?? 60000
+    const abortController = new AbortController()
     let messages: ModelMessage[]
 
     if (typeof model.prompt === 'string') {
@@ -231,7 +229,7 @@ ${data.jobData.jobDescription}`,
     }
     let index = -1
     const stream = await agent.stream({
-      timeout,
+      abortSignal: abortController.signal,
       messages,
       onStart: (m) => {
         logger.debug('Chat start', m, stream)
@@ -257,6 +255,24 @@ ${data.jobData.jobDescription}`,
       },
     })
 
+    // Idle timeout: reset on every chunk, only fires when no data flows for idleTimeout ms
+    let idleTimer: ReturnType<typeof setTimeout> | null = null
+    const resetIdleTimer = () => {
+      if (idleTimer) clearTimeout(idleTimer)
+      idleTimer = setTimeout(() => {
+        state.status = 'error'
+        state.error = new Error(`AI 响应超时 (${idleTimeout / 1000}s 无数据)`)
+        abortController.abort()
+      }, idleTimeout)
+    }
+    const clearIdleTimer = () => {
+      if (idleTimer) {
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+    }
+    resetIdleTimer()
+
     state.pushMessage(msg)
     index = state.messages.findIndex((m) => m.id === msg.id)
 
@@ -275,6 +291,7 @@ ${data.jobData.jobDescription}`,
           return `Unknown error: ${err}`
         },
       })) {
+        resetIdleTimer()
         let part: (typeof msg.parts)[number] | null = null
         const lastPart = msg.parts[msg.parts.length - 1]
         switch (chunk.type) {
@@ -324,6 +341,8 @@ ${data.jobData.jobDescription}`,
       state.status = 'error'
       state.error = e as Error
       logger.error('Error during chat streaming', e)
+    } finally {
+      clearIdleTimer()
     }
 
     if (state.error) {

--- a/src/composables/useModel/index.ts
+++ b/src/composables/useModel/index.ts
@@ -37,8 +37,12 @@ export const useModel = () => {
     modelData.value = data
   }
 
-  async function save() {
+  async function persist() {
     await counter.storageSet(confModelKey, toRaw(modelData.value))
+  }
+
+  async function save() {
+    await persist()
     toast.add({
       title: '保存成功',
       color: 'success',
@@ -48,6 +52,7 @@ export const useModel = () => {
   return {
     initModel: init,
     modelData,
+    persistModel: persist,
     saveModel: save,
   }
 }

--- a/src/composables/useModel/openai.ts
+++ b/src/composables/useModel/openai.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from '@ai-sdk/openai'
-import { LanguageModelV3 } from '@ai-sdk/provider'
+import { LanguageModelV4 } from '@ai-sdk/provider'
 
 import { desc, other } from './common'
 import type { LLMConf, LLMInfo } from './type'
@@ -176,7 +176,7 @@ const info: LLMInfo<OpenaiLLMConf> = {
   },
 }
 
-const createModel: (conf: OpenaiLLMConf) => LanguageModelV3 = (conf: OpenaiLLMConf) => {
+const createModel: (conf: OpenaiLLMConf) => LanguageModelV4 = (conf: OpenaiLLMConf) => {
   const openai = createOpenAI({
     baseURL: conf.base_url,
     apiKey: conf.api_key,

--- a/src/composables/useStatistics.ts
+++ b/src/composables/useStatistics.ts
@@ -1,6 +1,6 @@
-import { reactiveComputed, watchThrottled } from '@vueuse/core'
+import { watchThrottled } from '@vueuse/core'
 
-import { ref } from '#imports'
+import { reactive, ref } from '#imports'
 import { counter } from '@/message'
 import type { Statistics } from '@/types/formData'
 import { getCurDay } from '@/utils'
@@ -10,23 +10,30 @@ import { logger } from '@/utils/logger'
 export const todayKey = 'local:web-geek-job-Today'
 export const statisticsKey = 'local:web-geek-job-Statistics'
 
+function createTodayData(date = getCurDay()): Statistics {
+  return {
+    date,
+    success: 0,
+    total: 0,
+    repeat: 0,
+    activityFilter: 0,
+    tasks: {},
+  }
+}
+
+const todayData = reactive<Statistics>(createTodayData())
+const statisticsData = ref<Statistics[]>([])
+let updateQueue = Promise.resolve<Statistics>(jsonClone(todayData))
+
+watchThrottled(
+  todayData,
+  (value) => {
+    void counter.storageSet(todayKey, jsonClone(value))
+  },
+  { throttle: 200 },
+)
+
 export const useStatistics = () => {
-  const date = getCurDay()
-
-  const todayData = reactiveComputed<Statistics>(() => {
-    const current = {
-      date,
-      success: 0,
-      total: 0,
-      repeat: 0,
-      activityFilter: 0,
-      tasks: {},
-    }
-    return current
-  })
-
-  const statisticsData = ref<Statistics[]>([])
-
   async function getStatistics(): Promise<string> {
     await updateStatistics()
     return JSON.stringify(jsonClone({ t: todayData, s: statisticsData.value }))
@@ -40,32 +47,34 @@ export const useStatistics = () => {
     await counter.storageSet(statisticsKey, s)
   }
 
-  watchThrottled(
-    todayData,
-    (v) => {
-      void counter.storageSet(todayKey, jsonClone(v))
-    },
-    { throttle: 200 },
-  )
+  function updateStatistics() {
+    const run = async () => {
+      const current = createTodayData()
+      const [storedToday, storedStatistics] = await Promise.all([
+        counter.storageGet<Statistics>(todayKey, current),
+        counter.storageGet<Statistics[]>(statisticsKey, []),
+      ])
 
-  async function updateStatistics(curData = jsonClone(todayData)) {
-    void counter.storageGet<Statistics[]>(statisticsKey, []).then((data) => {
-      statisticsData.value = data
-    })
+      logger.debug('统计数据:', current.date, storedToday)
+      if (storedToday.date === current.date) {
+        deepmerge(todayData, current, { clone: false })
+        deepmerge(todayData, storedToday, { clone: false })
+        statisticsData.value = storedStatistics
+        return jsonClone(todayData)
+      }
 
-    const g = await counter.storageGet(todayKey, curData)
-    logger.debug('统计数据:', date, g)
-    if (g.date === date) {
-      deepmerge(todayData, g, { clone: false })
-      return g
+      const newStatistics = storedToday.date ? [storedToday, ...storedStatistics] : storedStatistics
+      deepmerge(todayData, current, { clone: false })
+      statisticsData.value = newStatistics
+      await Promise.all([
+        counter.storageSet(statisticsKey, newStatistics),
+        counter.storageSet(todayKey, jsonClone(todayData)),
+      ])
+      return jsonClone(todayData)
     }
 
-    const statistics = await counter.storageGet(statisticsKey, [])
-
-    const newStatistics = [g, ...statistics]
-    await counter.storageSet(statisticsKey, newStatistics)
-    await counter.storageSet(todayKey, curData)
-    statisticsData.value = newStatistics
+    updateQueue = updateQueue.then(run, run)
+    return updateQueue
   }
 
   return {


### PR DESCRIPTION
## 修复概述

本 PR 修复了统计界面全是 NaN、日志界面无数据、AI 模型配置无法编辑/删除/保存、AI 筛选超时崩溃等问题。

## 统计界面修复
- **根因**：每次调用 `useStatistics()` 都创建新的 reactive 实例，工作流更新的实例和界面渲染的实例不是同一个；四个主计数器从未被写入；百分比公式除以 0 产生 NaN
- **修复**：改为模块级单例共享状态；工作流每个岗位处理完成后写入 total/success/repeat/activityFilter；百分比修正为 `*100`，total 为 0 时返回 `0.0`

## 日志界面修复
- **根因**：日志页硬编码"维护当中"，`helper.logs` 从未被任何生产者写入
- **修复**：工作流每个岗位处理结束后写入结构化日志；表格增加时间、级别、公司、薪酬、内容列；空状态改为中文提示，增加清空按钮；日志详情弹窗展示 AI 过滤结果和 AI 招呼语

## AI 模型配置修复
- **根因**：运行时 `createAgent` 直接用 `createOpenAI` + `provider.chat`，忽略了 Responses API、额外请求头和采样参数；测试用的 `openai.createModel` 路径完全不同
- **修复**：运行时统一使用 `openai.createModel()`；支持 Responses API 开关、额外请求头、temperature/top_p/penalties；移除 provider 缓存，每次重建读取最新配置

## AI 超时修复
- **根因**：整个请求用固定 `timeout` 包裹，模型思考期间没有数据流就超时
- **修复**：改为流式活跃检测——每收到一个 chunk 就重置计时器，只有持续无数据超过配置的 `timeout` 才中断；`abortSignal` 正确传递给 `agent.stream`

## 模型删除修复
- **根因**：`del()` 只改内存数组就提示成功，不调用 `saveModel()`
- **修复**：删除后立即 `persistModel()` 写入存储；自动清理 aiFiltering/aiGreeting/aiReply/record 中的失效引用；保存按钮增加成功/失败 toast 和上下文失效提示

## 招呼任务冲突修复
- **根因**：自定义招呼和 AI 招呼共用任务 ID `打招呼`，`rebuild()` 的 Map 去重导致后者覆盖前者
- **修复**：改为唯一 ID；AI 招呼开启时显式跳过自定义招呼

## AI 筛选解析健壮性
- **根因**：`parseFiltering` 假设 AI 返回固定格式 `{negative: [{reason, score}], positive: []}`，实际 AI 可能返回不同结构导致崩溃
- **修复**：`parseFiltering` 支持多种 AI 返回格式（数组/字符串/直接 rating）；AI 返回空值时安全跳过

## 验证
- ✅ `vue-tsc --noEmit` 类型检查通过
- ✅ `wxt build -b chrome` 构建成功
- ✅ 实际运行验证统计、日志、AI 功能正常

## 改动文件
17 files changed, 359 insertions(+), 155 deletions(-)