### PR TITLE
fix: 修复 README 中失效的 Star 趋势图

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ greasyfork地址(0.2旧版本): <https://greasyfork.org/zh-CN/scripts/491340>
 
 ## Star 趋势
 
-<a href="https://star-history.com/#ocyss/boss-helper&Date">
+<a href="https://star-history.dera.page/#ocyss/boss-helper&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ocyss/boss-helper&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ocyss/boss-helper&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ocyss/boss-helper&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ocyss/boss-helper&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ocyss/boss-helper&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ocyss/boss-helper&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star 趋势图已损坏，无法正常显示，需要修复。

此 PR 更新了图表链接，使 Star 趋势图恢复正常显示。